### PR TITLE
Replace match with if/elif for Python <3.10 compatibility

### DIFF
--- a/qutewindow/platforms/windows/title_bar/TitleBar.py
+++ b/qutewindow/platforms/windows/title_bar/TitleBar.py
@@ -48,8 +48,7 @@ class MaximizeButton(TitleBarButton):
         self.setIcon(Icon(u":/icons/title-bar/maximize.png"))
 
     def setState(self, state: MaximizeButtonState) -> None:
-        match state:
-            case MaximizeButtonState.HOVER:
+        if state == MaximizeButtonState.HOVER:
                 self.setStyleSheet("""
                     QPushButton {
                         background-position: center;
@@ -60,7 +59,7 @@ class MaximizeButton(TitleBarButton):
                         background-color: #1D1D24;
                     }
                     """)
-            case MaximizeButtonState.NORMAL:
+        elif state == MaximizeButtonState.NORMAL:
                  self.setStyleSheet("""
                     QPushButton {
                         background-position: center;


### PR DESCRIPTION
Currently, all functions but `setState` function uses if/elif rather than the match statement, this PR proposes a change of that function to allow for Python <3.10 compatibility aswell as staying consistent with the rest of the codebase.